### PR TITLE
Adding Articulated thruster feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
   dynamic_reconfigure
   mvp_msgs
+  urdf
 )
 
 find_package(GSL REQUIRED)

--- a/include/mvp_control/dictionary.h
+++ b/include/mvp_control/dictionary.h
@@ -64,9 +64,6 @@ namespace ctrl {
     static constexpr const char * CONF_THRUSTER_LIMITS = "thruster_limits";
     static constexpr const char * CONF_THRUSTER_MAX = "max";
     static constexpr const char * CONF_THRUSTER_MIN = "min";
-    static constexpr const char * CONF_SERVO_LIMITS = "servo_limits";
-    static constexpr const char * CONF_SERVO_MAX = "max_angle";
-    static constexpr const char * CONF_SERVO_MIN = "min_angle";
 
     static constexpr const char * CONF_GENERATOR_TYPE = "generator_type";
     static constexpr const char * CONF_GENERATOR_TYPE_OPT_TF = "tf";

--- a/include/mvp_control/dictionary.h
+++ b/include/mvp_control/dictionary.h
@@ -88,7 +88,8 @@ namespace ctrl {
     static constexpr const char * CONF_CONTROL_TF = "control_tf";
     static constexpr const char * CONF_CONTROL_TF_SERVO = "control_tf_servo";
     static constexpr const char * CONF_CONTROLLER_FREQUENCY = "controller_frequency";
-
+    static constexpr const char * CONF_NO_SETPOINT_TIMEOUT = "controller_no_setpoint_timeout";
+    
     static constexpr const char * TOPIC_SAFETY = "safety";
     static constexpr const char * TOPIC_STATUS = "status";
     static constexpr const char * TOPIC_CONTROL_PROCESS_VALUE = "controller/process/value";

--- a/include/mvp_control/dictionary.h
+++ b/include/mvp_control/dictionary.h
@@ -18,7 +18,11 @@
     Email: emircem@uri.edu;emircem.gezer@gmail.com
     Year: 2022
 
-    Copyright (C) 2022 Smart Ocean Systems Laboratory
+    Author: Farhang Naderi
+    Email: farhang.naderi@uri.edu;farhang.nba@gmail.com
+    Year: 2024
+
+    Copyright (C) 2024 Smart Ocean Systems Laboratory
 */
 
 #pragma once
@@ -45,13 +49,24 @@ namespace ctrl {
     static constexpr const char * CONF_DOF_YAW_RATE = "yaw_rate";
 
     static constexpr const char * CONF_THRUSTER_POLY = "thruster_polynomials";
+    static constexpr const char* CONF_SERVO_POLY = "servo_coefficients";
     static constexpr const char * CONF_THRUST_COMMAND_TOPICS = "thruster_command_topics";
+    static constexpr const char * CONF_SERVO_COMMAND_TOPICS = "servo_command_topics";
+    static constexpr const char * CONF_SERVO_JOINT_TOPIC = "servo_joint_topic";
+    static constexpr const char * CONF_SERVO_JOINT_TOPIC_DEFAULT = "/control/servos/joint_states";
+    static constexpr const char * CONF_SERVO_JOINT_SETPOINT_TOPIC = "servo_joint_setpoint_topic";
     static constexpr const char * CONF_THRUSTER_FORCE_TOPICS = "thruster_force_topics";
     static constexpr const char * CONF_THRUSTER_IDS = "thruster_ids";
+    static constexpr const char * CONF_SERVO_IDS = "servo_ids";
+    static constexpr const char * CONF_THRUSTER_SERVO_JOINTS = "thruster_servo_joints";
+    static constexpr const char * CONF_THRUSTER_SERVO_SPEEDS = "thruster_servo_speeds";
 
     static constexpr const char * CONF_THRUSTER_LIMITS = "thruster_limits";
     static constexpr const char * CONF_THRUSTER_MAX = "max";
     static constexpr const char * CONF_THRUSTER_MIN = "min";
+    static constexpr const char * CONF_SERVO_LIMITS = "servo_limits";
+    static constexpr const char * CONF_SERVO_MAX = "max_angle";
+    static constexpr const char * CONF_SERVO_MIN = "min_angle";
 
     static constexpr const char * CONF_GENERATOR_TYPE = "generator_type";
     static constexpr const char * CONF_GENERATOR_TYPE_OPT_TF = "tf";
@@ -74,8 +89,8 @@ namespace ctrl {
     static constexpr const char * CONF_PID_I_MIN = "i_min";
     static constexpr const char * CONF_CONTROL_ALLOCATION_MATRIX = "control_allocation_matrix";
     static constexpr const char * CONF_CONTROL_TF = "control_tf";
+    static constexpr const char * CONF_CONTROL_TF_SERVO = "control_tf_servo";
     static constexpr const char * CONF_CONTROLLER_FREQUENCY = "controller_frequency";
-
 
     static constexpr const char * TOPIC_SAFETY = "safety";
     static constexpr const char * TOPIC_STATUS = "status";

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,8 @@
   <depend>libgsl</depend>
   <depend>mvp_msgs</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>urdf</depend>
+  <depend>urdf_parser_plugin</depend>
   <doc_depend>doxygen</doc_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/mvp_control/mvp_control.h
+++ b/src/mvp_control/mvp_control.h
@@ -18,7 +18,11 @@
     Email: emircem@uri.edu;emircem.gezer@gmail.com
     Year: 2022
 
-    Copyright (C) 2022 Smart Ocean Systems Laboratory
+    Author: Farhang Naderi
+    Email: farhang.naderi@uri.edu;farhang.nba@gmail.com
+    Year: 2024
+
+    Copyright (C) 2024 Smart Ocean Systems Laboratory
 */
 
 
@@ -71,9 +75,47 @@ namespace ctrl {
         //! @brief Controlled freedoms
         std::vector<int> m_controlled_freedoms;
 
+        //! @brief Servo speeds for OSQP constraints
+        Eigen::VectorXd m_servo_speed;
+
+        //! @brief Upper limits for OSQP forces boundary conditions
         Eigen::VectorXd m_upper_limit;
 
+        //! @brief Lower limits for OSQP forces boundary conditions
         Eigen::VectorXd m_lower_limit;
+
+        //! @brief Upper angle limits vector
+        Eigen::VectorXd m_upper_angle;
+
+        //! @brief Lower angle limits vector
+        Eigen::VectorXd m_lower_angle;
+
+        //! @brief Vector representing thruster configuration
+        Eigen::VectorXd m_thruster_vector;
+
+        //! @brief TF prefix for thruster transformations
+        std::string m_tf_prefix_thruster;
+
+        //! @brief Controlled grequency
+        double m_controller_frequency; 
+
+        //! @brief Index of the current thruster
+        int m_thruster_index; 
+
+        //! @brief the angle between the thruster and the x-axis
+        double beta;
+
+        //! @brief Store the current angles for each servo
+        std::vector<double> m_current_angles; //
+
+        //! @brief Adjusted upper limit for thruster constraints
+        std::vector<int> m_adjusted_upper_limit;
+
+        //! @brief Adjusted lower limit for thruster constraints
+        std::vector<int> m_adjusted_lower_limit;
+
+        //! @brief Constants for solver
+        static constexpr double kInfinity = std::numeric_limits<double>::infinity();
 
         /** @brief Calculates PID using #MimoPID
          *
@@ -115,12 +157,14 @@ namespace ctrl {
         //! @brief Mutex lock for protect desired state during changes
         std::recursive_mutex m_desired_state_lock;
 
+        //! @brief Mutex lock to protect thruster states during changes
+        std::mutex m_thruster_vector_lock; 
+
     public:
         /**ns="alpha_control" @brief Mvp Control default constructor
          *
          */
         MvpControl();
-
 
         /** @brief Trivial Setter for control allocation matrix
          *
@@ -129,13 +173,61 @@ namespace ctrl {
         void set_control_allocation_matrix(
             const decltype(m_control_allocation_matrix) &matrix);
 
-
         /** @brief Trivial getter for thruster id
          *
          * @return #MvpControl::m_control_allocation_matrix
          */
         auto get_control_allocation_matrix() ->
         decltype(m_control_allocation_matrix);
+
+        /** @brief Trivial Setter for articulation state vector
+         *
+         * @param vector
+         */
+        void set_thruster_articulation_vector(
+            const decltype(m_thruster_vector) &vector);
+
+        /**
+         * @brief Trivial Setter for controller frequency
+         *
+         * @param frequency The new controller frequency value to set
+         */
+        void set_controller_frequency(
+            const decltype(m_controller_frequency) &frequency);
+
+        /**
+         * @brief Getter for controller frequency
+         *
+         * @return The current controller frequency value
+         */
+        decltype(m_controller_frequency) get_controller_frequency() const {
+            return m_controller_frequency;
+        }
+
+        /**
+         * @brief Trivial Setter for TF prefix
+         *
+         * @param prefix The new TF prefix value to set
+         */
+        void set_tf_prefix(const std::string &prefix) {
+            m_tf_prefix_thruster = prefix;
+        }
+
+        /**
+         * @brief Getter for TF prefix
+         *
+         * @return The current TF prefix value
+         */
+        std::string get_tf_prefix() const {
+            return m_tf_prefix_thruster;
+        }
+
+        /** @brief Trivial getter for thruster articulation vector
+         *
+         * @return The thruster articulation vector
+         */
+        auto get_thruster_articulation_vector() ->
+        decltype(m_thruster_vector);
 
         //! @brief Standard shared pointer type
         typedef std::shared_ptr<MvpControl> Ptr;
@@ -219,9 +311,56 @@ namespace ctrl {
         void
         update_desired_state(const decltype(m_desired_state) &desired_state);
 
+        /** @brief Set the current angle.
+         *
+         * Updates the current angle of the specified thruster.
+         * @param m_thruster_index Pointer to the index of the thruster.
+         * @param angle The new current angle to set.
+         */
+        void set_current_angle(const int* m_thruster_index, double angle);
+
+        /** @brief Get the current angle.
+         *
+         * Retrieves the current angle of the specified thruster.
+         * @param m_thruster_index Pointer to the index of the thruster.
+         * @return The current angle.
+         */
+        double get_current_angle(const int* m_thruster_index) const;
+
+        /** @brief Set the lower limit for OSQP boundary conditions
+        *
+        * Updates the lower limit of the system for OSQP boundary conditions.
+        * @param lower_limit The new lower limit to set.
+        */
         void set_lower_limit(const decltype(m_lower_limit) &lower_limit);
 
+        /** @brief Set the upper limit for OSQP boundary conditions
+        *
+        * Updates the upper limit of the system for OSQP boundary conditions.
+        * @param upper_limit The new upper limit to set.
+        */
         void set_upper_limit(const decltype(m_upper_limit) &upper_limit);
+
+        /** @brief Set the lower angle limit
+         *
+         * Updates the lower angle limit of the system.
+         * @param lower_angle The new lower angle limit to set.
+         */
+        void set_lower_angle(const decltype(m_lower_angle) &lower_angle);
+
+        /** @brief Set the upper angle limit
+         *
+         * Updates the upper angle limit of the system.
+         * @param upper_angle The new upper angle limit to set.
+         */
+        void set_upper_angle(const decltype(m_upper_angle) &upper_angle);
+
+        /** @brief Set the servo speed
+         *
+         * Updates the servo speed of the system.
+         * @param servo_speed The new servo speed to set.
+         */
+        void set_servo_speed(const decltype(m_servo_speed) &servo_speed);
 
     };
 

--- a/src/mvp_control/mvp_control_ros.cpp
+++ b/src/mvp_control/mvp_control_ros.cpp
@@ -18,15 +18,17 @@
     Email: emircem@uri.edu;emircem.gezer@gmail.com
     Year: 2022
 
-    Copyright (C) 2022 Smart Ocean Systems Laboratory
+    Author: Farhang Naderi
+    Email: farhang.naderi@uri.edu;farhang.nba@gmail.com
+    Year: 2024
+
+    Copyright (C) 2024 Smart Ocean Systems Laboratory
 */
 
 #include "mvp_control_ros.h"
 #include "exception.hpp"
 #include "tf2_eigen/tf2_eigen.h"
-
 #include "mvp_control/dictionary.h"
-
 #include "boost/regex.hpp"
 
 using namespace ctrl;
@@ -75,6 +77,17 @@ MvpControlROS::MvpControlROS()
             CONF_ODOMETRY_SOURCE_DEFAULT
     );
 
+    // Read configuration: joints topic id
+    std::string joint_states_topic;
+    m_pnh.param<std::string>(
+            CONF_SERVO_JOINT_TOPIC,
+            joint_states_topic, ""
+    );
+
+    if (joint_states_topic.empty()) {
+        ROS_ERROR("The joint_states_topic parameter is not set!");
+    }
+
     m_pnh.param<double>(
         CONF_CONTROLLER_FREQUENCY,
         m_controller_frequency,
@@ -88,6 +101,13 @@ MvpControlROS::MvpControlROS()
             odometry_topic,
             100,
             &MvpControlROS::f_cb_msg_odometry,
+            this
+    );
+
+    m_joint_state_subscriber = m_nh.subscribe<sensor_msgs::JointState>(
+            joint_states_topic,
+            100,
+            &MvpControlROS::f_cb_msg_joint_state,
             this
     );
 
@@ -209,7 +229,7 @@ MvpControlROS::MvpControlROS()
 
 void MvpControlROS::f_generate_control_allocation_matrix() {
 
-    // Read generator type
+    // Read generator type (e.g., TF or User-defined)
     std::string generator_type;
     m_pnh.param<std::string>(
             CONF_GENERATOR_TYPE,
@@ -226,7 +246,7 @@ void MvpControlROS::f_generate_control_allocation_matrix() {
         m_generator_type = GeneratorType::UNKNOWN;
     }
 
-    // Generate the control allocation matrix
+    // Generate the control allocation matrix based on the specified generator type
     if(m_generator_type == GeneratorType::USER) {
         f_generate_control_allocation_from_user();
     } else if (m_generator_type == GeneratorType::TF) {
@@ -236,10 +256,28 @@ void MvpControlROS::f_generate_control_allocation_matrix() {
             "control allocation generation method unspecified"
         );
     }
-
-    // Conduct some checks to see if everything is ready to be initialized
+       
+    // Conduct some checks to ensure everything is ready for initialization
     if(m_thrusters.empty()) {
         throw control_ros_exception("no thruster specified");
+    } else {
+        for(size_t i = 0; i < m_thrusters.size(); i++) {
+            std::string id = m_thrusters[i]->get_id();
+            int isArticulated = m_thrusters[i]->get_is_articulated();
+            std::vector<std::string> servoJoints = m_thrusters[i]->get_servo_joints();
+            std::string link = m_thrusters[i]->get_link_id();
+            
+            // Log details of each thruster, including whether it's articulated and its associated joints
+            ROS_INFO_STREAM("Thruster " << i << ": ID=" << id << ", Is Articulated=" << (isArticulated > 0 ? "Yes" : "No") << ", Link=" << link);
+            
+            if(isArticulated > 0) {
+                std::string jointsStr;
+                for(const auto& joint : servoJoints) {
+                    jointsStr += joint + " ";
+                }
+                ROS_INFO_STREAM("  Joint: " << jointsStr);
+            }
+        }
     }
 
     // Control allocation matrix is generated based on each thruster. Each
@@ -254,10 +292,18 @@ void MvpControlROS::f_generate_control_allocation_matrix() {
             );
         }
     }
+    Eigen::VectorXd m_thruster_vector = Eigen::VectorXd::Zero(m_thrusters.size());
 
-    // Initialize the control allocation matrix based on zero matrix.
-    // M by N matrix. M -> number of all controllable DOF, N -> number of
-    // thrusters
+    for (int i = 0; i < m_thrusters.size(); i++) {
+        m_thruster_vector[i] = m_thrusters[i]->get_is_articulated();
+    }
+
+    m_mvp_control->set_thruster_articulation_vector(m_thruster_vector);
+    m_mvp_control->set_controller_frequency(m_controller_frequency);
+    m_mvp_control-> set_tf_prefix(m_tf_prefix);
+    
+    // Initialize the control allocation matrix with zeros.
+    // M -> number of controllable DOFs, N -> number of thrusters
     m_control_allocation_matrix = Eigen::MatrixXd::Zero(
         CONTROLLABLE_DOF_LENGTH, (int) m_thrusters.size()
     );
@@ -265,9 +311,8 @@ void MvpControlROS::f_generate_control_allocation_matrix() {
     // Until this point, all the allocation matrix related issued must be
     // solved or exceptions thrown.
 
-
-    // Acquire DOF per actuator. Register it to control allocation matrix.
-    // Only DOF::X, DOF::Y and DOF::Z are left unregistered. They are computed
+    // Register each DOF per actuator to the control allocation matrix.
+    // Only DOFs X, Y, and Z are left unregistered. They are computed
     // online after each iteration.
     for (int i = 0; i < m_thrusters.size(); i++) {
         for(const auto& j :
@@ -281,69 +326,155 @@ void MvpControlROS::f_generate_control_allocation_matrix() {
         }
     }
 
-    // Finally, set the control allocation matrix for the controller object.
+    // Set the final control allocation matrix for the controller object
     m_mvp_control->set_control_allocation_matrix(m_control_allocation_matrix);
 
 }
 
 void MvpControlROS::f_generate_thrusters() {
-    // Read all the configuration file to get all the listed thrusters
 
-
-    if(!m_pnh.hasParam(CONF_THRUSTER_IDS)) {
+    if (!m_pnh.hasParam(CONF_THRUSTER_IDS)) {
         throw control_ros_exception("thruster_ids empty");
     }
 
     std::vector<std::string> thruster_id_list;
     m_pnh.getParam(CONF_THRUSTER_IDS, thruster_id_list);
 
-    // create thruster objects
-    for(const auto& id : thruster_id_list) {
+    std::map<std::string, std::string> thruster_servo_joints;
+    m_pnh.getParam(CONF_THRUSTER_SERVO_JOINTS, thruster_servo_joints);
+
+    // First Stage: Initialization with Articulated Check
+    for (const auto& id : thruster_id_list) {
+        
+        // Check if the current thruster is articulated
+        auto it = thruster_servo_joints.find(id);
+        int isArticulated = (it != thruster_servo_joints.end()) ? 1 : 0;
+       // Create a ThrusterROS object for the non-articulated or the first articulated joint
         ThrusterROS::Ptr t(new ThrusterROS());
-        t->set_id(std::string(id));
-        m_thrusters.emplace_back(t);
+        t->set_id(id);
+        t->set_is_articulated(isArticulated);
+
+        if (isArticulated == 0) {
+            // Thruster is not articulated
+            ROS_INFO_STREAM("Thruster " << id << " is not articulated.");
+            // Add the non-articulated thruster to the list
+            m_thrusters.emplace_back(t);
+        } else {
+            /* 
+            Thruster is articulated, create two ThrusterROS objects: 
+            */
+            ThrusterROS::Ptr articulated_tx(new ThrusterROS());
+            articulated_tx->set_id(id);
+            articulated_tx->set_is_articulated(1);
+            articulated_tx->set_servo_joints({it->second}); // Set the first servo joint
+            
+            // Log the first servo joint
+            ROS_INFO_STREAM("Thruster " << id << " is articulated with servo joint: " << it->second);
+            
+            m_thrusters.emplace_back(articulated_tx);
+
+            ThrusterROS::Ptr articulated_ty(new ThrusterROS());
+            articulated_ty->set_id(id);
+            articulated_ty->set_is_articulated(2);
+            articulated_ty->set_servo_joints({it->second}); // Set the second servo joint
+            
+            // Log the second servo joint
+            ROS_INFO_STREAM("Thruster " << id << " is articulated with servo joint: " << it->second);
+            
+            m_thrusters.emplace_back(articulated_ty);
+        }
     }
 
-    // initialize thrust command publishers
-    for(const auto& t : m_thrusters) {
+    // Second Stage: Detailed Configuration for Each Thruster
+    for (const auto& t : m_thrusters) {
+        std::string thrust_command_topic_id, thrust_force_topic_id;
+        std::string servo_joint_desired_topic_id,servo_command_topic_id;
+        std::vector<double> poly;
+        double force_max, force_min;
+        double angle_max, angle_min, omega;
 
-        // read topic id config for thruster
-        std::string thrust_command_topic_id;
-        m_pnh.param<std::string>(std::string()
-                + CONF_THRUST_COMMAND_TOPICS + "/" + t->m_id,
-                thrust_command_topic_id,
-                "control/thruster/" + t->m_id + "/command");
+        // Thrust command topic configuration
+        m_pnh.param<std::string>(
+            std::string(CONF_THRUST_COMMAND_TOPICS) + "/" + t->get_id(), 
+            thrust_command_topic_id, 
+            "control/thruster/" + t->get_id() + "/command");
         t->set_thrust_command_topic_id(thrust_command_topic_id);
 
-        // read topic id config for thruster
-        std::string thrust_force_topic_id;
-        m_pnh.param<std::string>(std::string()
-                + CONF_THRUSTER_FORCE_TOPICS + "/" + t->m_id,
-                thrust_force_topic_id,
-                "control/thruster/" + t->m_id + "/force"
-        );
+        // Thrust force topic configuration
+        m_pnh.param<std::string>(
+            std::string(CONF_THRUSTER_FORCE_TOPICS) + "/" + t->get_id(), 
+            thrust_force_topic_id, 
+            "control/thruster/" + t->get_id() + "/force");
         t->set_thrust_force_topic_id(thrust_force_topic_id);
 
-        // read polynomials for thruster
-        std::vector<double> poly;
-        m_pnh.param<std::vector<double>>(std::string()
-                + CONF_THRUSTER_POLY + "/" + t->m_id,
-                poly,
-                std::vector<double>()
-        );
+        // Joint state topic configuration
+        m_pnh.param<std::string>(
+            "/" + m_tf_prefix + std::string(CONF_SERVO_JOINT_SETPOINT_TOPIC), 
+            servo_joint_desired_topic_id, 
+            "/" + m_tf_prefix + "control/servos/desired_joint_states");
+        t->set_joint_state_desired_topic_id(servo_joint_desired_topic_id);
+        
+        // Servo command topic configuration
+        m_pnh.param<std::string>(std::string(CONF_SERVO_COMMAND_TOPICS) + "/" + t->get_id(), 
+                                servo_command_topic_id, 
+                                "");
+        t->set_servo_command_topic_id(servo_command_topic_id);
+
+        // Polynomial coefficients configuration for thrusters
+        m_pnh.param<std::vector<double>>(
+            std::string(CONF_THRUSTER_POLY) + "/" + t->get_id(), 
+            poly, std::vector<double>());
         t->get_poly_solver()->set_coeff(poly);
 
-        m_pnh.param<double>(std::string() +
-            CONF_THRUSTER_LIMITS + "/" + t->get_id() + "/" + CONF_THRUSTER_MAX,
-            t->m_force_max,
+        // Read servo coefficients from the configuration file
+        std::vector<double> servo_poly;
+        m_pnh.param<std::vector<double>>(
+            std::string(CONF_SERVO_POLY) + "/" + t->get_id(), 
+            servo_poly, std::vector<double>());
+        t->set_servo_coeff(servo_poly);
+
+        // Servo speeds in rad/s
+        if (!m_pnh.getParam(std::string(CONF_THRUSTER_SERVO_SPEEDS) + "/" + t->get_id(), omega)) {
+            ROS_WARN("'%s' not set. Assuming as non-articulated and setting to zero.", 
+                    (std::string(CONF_THRUSTER_SERVO_SPEEDS) + ":" + t->get_id()).c_str());
+        } else {
+            t->m_omega = omega;
+        }
+
+        // Force limits configuration
+        m_pnh.param<double>(
+            std::string(CONF_THRUSTER_LIMITS) + "/" + t->get_id() + "/" + CONF_THRUSTER_MAX, 
+            force_max, 
             10.0);
+        t->m_force_max = force_max;
 
-        m_pnh.param<double>(std::string() +
-            CONF_THRUSTER_LIMITS + "/" + t->get_id() + "/" + CONF_THRUSTER_MIN,
-            t->m_force_min,
+        m_pnh.param<double>(
+            std::string(CONF_THRUSTER_LIMITS) + "/" + t->get_id() + "/" + CONF_THRUSTER_MIN, 
+            force_min, 
             -10.0);
-    }
+        t->m_force_min = force_min;
 
+        /*
+        Angle limits configuration
+        For safety the default angle values are passed zero 
+        in case no input available in config file.
+        */
+
+        if (!m_pnh.getParam(std::string(CONF_SERVO_LIMITS) + "/" + t->get_id() + "/" + CONF_SERVO_MAX, angle_max)) {
+            ROS_WARN(" '%s' not set. Assuming as non-articulated and setting to zero.",
+                    (std::string(CONF_SERVO_LIMITS) + ":" + t->get_id() + ":" + CONF_SERVO_MAX).c_str());
+        } else {
+            t->m_angle_max = angle_max;
+        }
+
+        if (!m_pnh.getParam(std::string(CONF_SERVO_LIMITS) + "/" + t->get_id() + "/" + CONF_SERVO_MIN, angle_min)) {
+            ROS_WARN(" '%s' not set. Assuming as non-articulated and setting to zero.",
+                    (std::string(CONF_SERVO_LIMITS) + ":" + t->get_id() + ":" + CONF_SERVO_MIN).c_str());
+        } else {
+            t->m_angle_min = angle_min;
+        }
+
+    }
 }
 
 void MvpControlROS::initialize() {
@@ -352,7 +483,7 @@ void MvpControlROS::initialize() {
     f_read_control_modes();
 
     // Generate thrusters with the given configuration
-    f_generate_thrusters();
+     f_generate_thrusters();
 
     // Generate control allocation matrix with defined method
     f_generate_control_allocation_matrix();
@@ -415,7 +546,19 @@ void MvpControlROS::f_generate_control_allocation_from_tf() {
 
         t->set_link_id(m_tf_prefix + link_id);
     }
-
+    
+    for (const auto& t : m_thrusters) {
+        std::string servo_link_id;
+        std::string param_name = std::string() + CONF_CONTROL_TF_SERVO + "/" + t->get_id();
+        
+        if (m_pnh.getParam(param_name, servo_link_id)) {
+            t->set_servo_link_id(m_tf_prefix + servo_link_id);
+        } else {
+            ROS_WARN("Parameter %s not found. No Servo Link!", param_name.c_str());
+            continue;
+        }
+    }
+        
     // For each thruster look up transformation
     for(const auto& t : m_thrusters) {
 
@@ -431,16 +574,12 @@ void MvpControlROS::f_generate_control_allocation_from_tf() {
 
             eigen_tf = tf2::transformToEigen(tf_cg_thruster);
         } catch(tf2::TransformException &e) {
-            ROS_WARN_STREAM_THROTTLE(10, std::string("Can't compute thruster tf between cg-thruster: ") + e.what());
+            ROS_WARN_STREAM_THROTTLE(10, 
+            std::string("Can't compute thruster tf between cg-thruster: ") + e.what());
             return;
         }
 
         Eigen::VectorXd contribution_vector(CONTROLLABLE_DOF_LENGTH);
-
-        // thruster onlu use a axis (e.g., X-axis) for forece
-        double Fx = eigen_tf.rotation()(0, 0);
-        double Fy = eigen_tf.rotation()(1, 0);
-        double Fz = eigen_tf.rotation()(2, 0);
 
         auto trans_xyz = eigen_tf.translation();
 
@@ -474,10 +613,37 @@ void MvpControlROS::f_generate_control_allocation_from_tf() {
             return;
         }
 
+        double Fx, Fy, Fz; 
+
+        Eigen::Vector3d transformedVector;
+
+        switch (t->get_is_articulated()) {
+            case 0: //Non-articulated thruster
+                transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitX();
+                Fx = transformedVector.x(); 
+                Fy = transformedVector.y();
+                Fz = transformedVector.z();
+                break;
+            case 1: //Decoupled articulated thruster along X in trhuster frame
+                transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitX();
+                Fx = transformedVector.x(); 
+                Fy = transformedVector.y();
+                Fz = transformedVector.z();
+                break;
+            case 2: //Decoupled articulated thruster along Y in trhuster frame
+                transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitY();
+                Fx = transformedVector.x(); 
+                Fy = transformedVector.y();
+                Fz = transformedVector.z();
+                break;
+            default:
+                ROS_WARN_STREAM("Invalid articulation index value for thruster " << t->get_id());
+                break;
+        }
+
         auto torque_pqr = trans_xyz.cross(Eigen::Vector3d{Fx, Fy, Fz});
         auto torque_rpy = ang_vel_tranform * torque_pqr;
-
-        //
+        // body frame forces and torques
         contribution_vector(DOF::SURGE) = Fx;
         contribution_vector(DOF::SWAY) = Fy;
         contribution_vector(DOF::HEAVE) = Fz;
@@ -495,7 +661,7 @@ void MvpControlROS::f_generate_control_allocation_from_tf() {
 
 bool MvpControlROS::f_update_control_allocation_matrix() {
 
-    // update control allocation based on actuators as well
+    // update control allocation based on actuators
 
     try {
         // Transform center of gravity to world
@@ -505,7 +671,7 @@ bool MvpControlROS::f_update_control_allocation_matrix() {
             ros::Time(0)
         );
         //only contiue the process if the tf is not too old
-        
+
         if (abs(cg_world.header.stamp.toSec() - ros::Time::now().toSec()) < 10.0 || cg_world.header.stamp.toSec()==0.0) 
         { 
             auto tf_eigen = tf2::transformToEigen(cg_world);
@@ -523,37 +689,90 @@ bool MvpControlROS::f_update_control_allocation_matrix() {
                 orientation(DOF::YAW)
             );
 
-            Eigen::Matrix3d ang_vel_tranform = Eigen::Matrix3d::Identity();
+            Eigen::Matrix3d ang_vel_transform = Eigen::Matrix3d::Identity();
 
             // for each thruster compute contribution in earth frame
             for(int j = 0 ; j < m_control_allocation_matrix.cols() ; j++){
-                Eigen::Vector3d uvw;
-                uvw <<
-                    m_control_allocation_matrix(DOF::SURGE, j),
-                    m_control_allocation_matrix(DOF::SWAY, j),
-                    m_control_allocation_matrix(DOF::HEAVE, j);
+
+                Eigen::Isometry3d eigen_tf;
+                try {
+                    // Assuming m_thrusters[j] gives access to the j-th thruster object
+                    auto tf_cg_thruster = m_transform_buffer.lookupTransform(
+                        m_cg_link_id,
+                        m_thrusters[j]->get_link_id(), 
+                        ros::Time(0)
+                    );
+
+                    eigen_tf = tf2::transformToEigen(tf_cg_thruster);
+                } catch(tf2::TransformException &e) {
+                    ROS_WARN_STREAM_THROTTLE(10, std::string("Can't compute thruster tf: ") + e.what());
+                    continue;
+                }
+
+                double Fx, Fy, Fz; 
+
+                Eigen::Vector3d transformedVector;
+                int isArticulated = m_thrusters[j]->get_is_articulated();
+
+                switch (isArticulated) {
+                    case 0: //Non-articulated thruster
+                        transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitX();
+                        Fx = transformedVector.x(); 
+                        Fy = transformedVector.y();
+                        Fz = transformedVector.z();
+                        break;
+                    case 1: //Decoupled articulated thruster along X in trhuster frame
+                        transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitX();
+                        Fx = transformedVector.x(); 
+                        Fy = transformedVector.y();
+                        Fz = transformedVector.z();
+                        break;
+                    case 2: //Decoupled articulated thruster along Y in trhuster frame
+                        transformedVector = eigen_tf.rotation() * Eigen::Vector3d::UnitY();
+                        Fx = transformedVector.x(); 
+                        Fy = transformedVector.y();
+                        Fz = transformedVector.z();
+                        break;
+                    default:
+                        ROS_WARN_STREAM("Invalid articulation index value for thruster " << m_thrusters[j]->get_id());
+                        break;
+                }
+
+                /*
+                Forces and pqr have to be updated again in 
+                case of rotation 
+                */
+                m_control_allocation_matrix(DOF::SURGE, j) = Fx;
+                m_control_allocation_matrix(DOF::SWAY, j) = Fy;
+                m_control_allocation_matrix(DOF::HEAVE, j) = Fz;
+
+                Eigen::Vector3d uvw(Fx, Fy, Fz);
 
                 Eigen::Vector3d xyz = tf_eigen.rotation() * uvw;
 
                 m_control_allocation_matrix(DOF::X, j) = xyz(0);
                 m_control_allocation_matrix(DOF::Y, j) = xyz(1);
                 m_control_allocation_matrix(DOF::Z, j) = xyz(2);
-                
+
+                auto trans_xyz = eigen_tf.translation();
+                auto torque_pqr = trans_xyz.cross(Eigen::Vector3d{Fx, Fy, Fz});
+
                 // Convert prq to world_frame angular rate:
                 //  Eq.(2.12), Eq.(2.14) from Thor I. Fossen, Guidance and Control of Ocean Vehicles, Page 10
-                Eigen::Vector3d pqr;
-                pqr <<
-                    m_control_allocation_matrix(DOF::ROLL_RATE, j),
-                    m_control_allocation_matrix(DOF::PITCH_RATE, j),
-                    m_control_allocation_matrix(DOF::YAW_RATE, j);                
+                
+                m_control_allocation_matrix(DOF::ROLL_RATE, j) = torque_pqr(0);
+                m_control_allocation_matrix(DOF::PITCH_RATE, j) = torque_pqr(1),
+                m_control_allocation_matrix(DOF::YAW_RATE, j) = torque_pqr(2);
 
-                ang_vel_tranform = f_angular_velocity_transform(orientation);
+                Eigen::Vector3d pqr(torque_pqr(0),torque_pqr(1),torque_pqr(2));               
 
-                auto rpy = ang_vel_tranform * pqr;
+                ang_vel_transform = f_angular_velocity_transform(orientation);
+
+                auto rpy = ang_vel_transform * pqr;
                 m_control_allocation_matrix(DOF::ROLL, j) = rpy(0);
                 m_control_allocation_matrix(DOF::PITCH, j) = rpy(1);
-                m_control_allocation_matrix(DOF::YAW, j) = rpy(2);       
-            }      
+                m_control_allocation_matrix(DOF::YAW, j) = rpy(2);             
+            }
         }
         else
         {
@@ -573,14 +792,53 @@ bool MvpControlROS::f_update_control_allocation_matrix() {
     Eigen::VectorXd upper_limit(m_thrusters.size());
     Eigen::VectorXd lower_limit(m_thrusters.size());
 
-    for(int i = 0 ; i < m_thrusters.size() ; i++) {
+    for(int i = 0; i < m_thrusters.size(); i++) {
+        // Default values for upper and lower limits
         upper_limit[i] = m_thrusters[i]->m_force_max;
         lower_limit[i] = m_thrusters[i]->m_force_min;
+
     }
 
     m_mvp_control->set_lower_limit(lower_limit);
 
     m_mvp_control->set_upper_limit(upper_limit);
+
+    // Define vectors for upper and lower angle limits
+    Eigen::VectorXd angle_upper_limit(m_thrusters.size());
+    Eigen::VectorXd angle_lower_limit(m_thrusters.size());
+
+    for (int i = 0; i < m_thrusters.size(); i++) {
+        // Check if m_angle_max is available
+        if (m_thrusters[i]->m_angle_max != -1) {
+            angle_upper_limit[i] = m_thrusters[i]->m_angle_max;
+        } else {
+            angle_upper_limit[i] = 0;
+        }
+
+        // Check if m_angle_min is available
+        if (m_thrusters[i]->m_angle_min != -1) {
+            angle_lower_limit[i] = m_thrusters[i]->m_angle_min;
+        } else {
+            angle_lower_limit[i] = 0;
+        }
+    }
+
+    m_mvp_control->set_lower_angle(angle_lower_limit);
+    m_mvp_control->set_upper_angle(angle_upper_limit);
+
+    // Define vector for servo speeds
+    Eigen::VectorXd servo_speed(m_thrusters.size());
+
+    for (int i = 0; i < m_thrusters.size(); i++) {
+        // Check if m_omega is available
+        if (m_thrusters[i]->m_omega != -1) {
+            servo_speed[i] = m_thrusters[i]->m_omega;
+        } else {
+            servo_speed[i] = 0;
+        }
+    }
+
+    m_mvp_control->set_servo_speed(servo_speed);
 
     return true;
 }
@@ -681,7 +939,7 @@ bool MvpControlROS::f_compute_process_values() {
         }
         else
         {
-            // printf("time %lf, dt=%lf \r\n", cg_odom.header.stamp.toSec(), ros::Time::now().toSec());
+            //printf("time %lf, dt=%lf \r\n", cg_odom.header.stamp.toSec(), ros::Time::now().toSec());
             ROS_WARN( "%s to %s TF too old!", m_cg_link_id.c_str(), m_odometry_msg.child_frame_id.c_str() );
             return false;
         }
@@ -738,7 +996,6 @@ bool MvpControlROS::f_compute_process_values() {
     return true;
 }
 
-
 void MvpControlROS::f_control_loop() {
 
     double pt = ros::Time::now().toSec();
@@ -785,11 +1042,73 @@ void MvpControlROS::f_control_loop() {
          * do not send commands to thrusters.
          */
         if(m_mvp_control->calculate_needed_forces(&needed_forces, dt)) {
+            for(int i = 0; i < m_thrusters.size(); ) {
+                auto is_articulated = m_thrusters.at(i)->get_is_articulated();
 
-            for(int i = 0 ; i < m_thrusters.size() ; i++) {
-                m_thrusters.at(i)->request_force(needed_forces(i));
+                int index = i;
+
+                if(is_articulated == 1) {
+                    if(i + 1 < m_thrusters.size()) {
+                        auto combined_force = sqrt(pow(needed_forces(i), 2) + pow(needed_forces(i + 1), 2));
+                        m_thrusters.at(i)->request_force(combined_force);
+
+                        std::string thruster_link_id = m_thrusters.at(i)->get_link_id();
+                        std::string servo_link_id = m_thrusters.at(i)->get_servo_link_id();
+                        std::string joint_name = m_tf_prefix + m_thrusters.at(i)->get_servo_joints().at(0);
+                        double current_angle;  // This will hold the computed angle in the x-z plane
+                        try {
+
+                            auto tf_servo_thruster = m_transform_buffer.lookupTransform(
+                                servo_link_id, 
+                                thruster_link_id,  
+                                ros::Time(0),
+                                ros::Duration(5.0)
+                            );
+
+                            // Extract the quaternion from the transformation
+                            geometry_msgs::Quaternion quat_msg = tf_servo_thruster.transform.rotation;
+                            tf2::Quaternion tf_quat;
+                            tf2::fromMsg(quat_msg, tf_quat);
+
+                            // Convert the quaternion to a rotation matrix
+                            tf2::Matrix3x3 m(tf_quat);
+
+                            // Extract the roll, pitch, and yaw angles from the rotation matrix
+                            double roll, pitch, yaw;
+                            m.getRPY(roll, pitch, yaw);
+
+                            current_angle = yaw;
+
+                            m_mvp_control->set_current_angle(&index, current_angle);
+
+                        } catch (tf2::TransformException &ex) {
+                            ROS_WARN("%s", ex.what());
+                            continue; // Skip this iteration if the transform is unavailable
+                        }
+
+                        // Calculate the angle to be requested
+                        double x = needed_forces(i);
+                        double y = needed_forces(i + 1);
+                        double calculated_angle = atan2(y, x); 
+
+                        // Calculate the new angle since it is needed in body frame within -pi to pi
+                        double new_angle = current_angle + calculated_angle;
+                        
+                        m_thrusters.at(i)->request_joint_angles(joint_name, new_angle);
+
+                        i += 2;  // Move to the next pair of articulated thrusters
+                    } else {
+                        ROS_WARN_STREAM("Expected articulated partner for thruster " << i << " but none found. Skipping.");
+                        i++; // Just move to next to avoid infinite loop in case of error
+                    }
+                } else {
+                    m_thrusters.at(i)->request_force(needed_forces(i));
+                    //not articulated so no rotation state
+                    m_mvp_control->set_current_angle(&index, 0);
+                    i++; // Move to the next thruster
+                }
+
             }
-
         }
 
         /**
@@ -804,6 +1123,12 @@ void MvpControlROS::f_cb_msg_odometry(
         const nav_msgs::Odometry::ConstPtr &msg) {
     std::scoped_lock lock(m_odom_lock);
     m_odometry_msg = *msg;
+}
+
+void MvpControlROS::f_cb_msg_joint_state(
+        const sensor_msgs::JointState::ConstPtr &msg) {
+    std::scoped_lock lock(m_joint_state_lock);
+    m_latest_joint_state = *msg;
 }
 
 void MvpControlROS::f_cb_srv_set_point(
@@ -1189,7 +1514,6 @@ bool MvpControlROS::f_cb_srv_disable(
     return true;
 }
 
-
 bool MvpControlROS::f_cb_srv_get_controller_state(
         std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &resp) {
     resp.success = true;
@@ -1202,7 +1526,6 @@ bool MvpControlROS::f_cb_srv_get_controller_state(
 
     return true;
 }
-
 
 bool MvpControlROS::f_cb_srv_get_active_mode(
     mvp_msgs::GetControlMode::Request& req,
@@ -1375,7 +1698,6 @@ bool MvpControlROS::f_amend_control_mode(std::string mode) {
         return true;
     }
 }
-
 
 bool MvpControlROS::f_amend_set_point(
     const mvp_msgs::ControlProcess &set_point) {

--- a/src/mvp_control/mvp_control_ros.h
+++ b/src/mvp_control/mvp_control_ros.h
@@ -99,6 +99,9 @@ namespace ctrl {
             UNKNOWN
         };
 
+        //! @brief urdf model 
+        urdf::Model m_model; 
+
         //! @brief Public node handler
         ros::NodeHandle m_nh;
 
@@ -271,6 +274,20 @@ namespace ctrl {
          *
          */
         void f_control_loop();
+
+        /**
+         * @brief Retrieves the joint limits for a specified joint.
+         *
+         * This function looks up the joint limits (lower and upper bounds) for a given joint in the URDF model.
+         * It is typically used to obtain the joint angle limits from the robot's URDF description.
+         *
+         * @param model The URDF model containing the joint.
+         * @param joint_name The name of the joint for which the limits are requested.
+         * @param lower The lower limit of the joint (output parameter).
+         * @param upper The upper limit of the joint (output parameter).
+         * @return True if the joint limits were successfully retrieved, false otherwise.
+         */
+        bool f_getJointLimits(const urdf::Model &model, const std::string &joint_name, double &lower, double &upper);
 
         /** @brief Retrieves the current position of a specified joint.
          *

--- a/src/mvp_control/mvp_control_ros.h
+++ b/src/mvp_control/mvp_control_ros.h
@@ -42,6 +42,7 @@
 #include "tf2_eigen/tf2_eigen.h"
 #include "tf2_ros/transform_listener.h"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 #include <urdf/model.h>
 
@@ -51,6 +52,7 @@
 #include "nav_msgs/Odometry.h"
 #include "dynamic_reconfigure/server.h"
 
+#include "geometry_msgs/PoseStamped.h"
 #include "mvp_control/PIDConfig.h"
 
 #include "mvp_msgs/PIDgains.h"
@@ -139,6 +141,12 @@ namespace ctrl {
 
         //! @brief Controller Frequency Param
         double m_controller_frequency;
+
+        //! @brief Controller timeout
+        double m_no_setpoint_timeout;
+
+        //! @brief setpont timer
+        double setpoint_timer;
 
         //! @brief Transform buffer for TF2
         tf2_ros::Buffer m_transform_buffer;
@@ -234,6 +242,17 @@ namespace ctrl {
          *  This method is called if generator_type is 'tf'
          */
         void f_generate_control_allocation_from_tf();
+
+        /**
+         * @brief Checks if required transformations are available.
+         * 
+         * Verifies the availability of the following transformations:
+         * - From the world frame to the center of gravity (CG) frame.
+         * - From the CG frame to each thruster frame.
+         * 
+         * @return True if all required transformations are found, otherwise False.
+         */
+        bool f_initial_tf_check();
 
         /** @brief Generates control allocation matrix from user input
          *

--- a/src/mvp_control/thruster_ros.cpp
+++ b/src/mvp_control/thruster_ros.cpp
@@ -18,7 +18,11 @@
     Email: emircem@uri.edu;emircem.gezer@gmail.com
     Year: 2022
 
-    Copyright (C) 2022 Smart Ocean Systems Laboratory
+    Author: Farhang Naderi
+    Email: farhang.naderi@uri.edu;farhang.nba@gmail.com
+    Year: 2024
+
+    Copyright (C) 2024 Smart Ocean Systems Laboratory
 */
 
 #include "thruster_ros.h"
@@ -29,8 +33,12 @@
 
 using namespace ctrl;
 
-ThrusterROS::ThrusterROS() {
+ThrusterROS::ThrusterROS() 
+        : m_nh() ,
+        m_pnh("~")
+{
     m_poly_solver.reset(new PolynomialSolver());
+
 }
 
 ThrusterROS::ThrusterROS(std::string id, std::string topic_id, Eigen::VectorXd contribution_vector) :
@@ -61,6 +69,29 @@ void ThrusterROS::set_thrust_force_topic_id(const decltype(m_thrust_force_topic_
     m_thrust_force_topic_id = topic_id;
 }
 
+auto ThrusterROS::get_servo_command_topic_id() -> decltype(m_servo_command_topic_id) {
+    return m_servo_command_topic_id;
+}
+
+void ThrusterROS::set_servo_command_topic_id(const decltype(m_servo_command_topic_id) &topic_id) {
+    m_servo_command_topic_id = topic_id;
+}
+auto ThrusterROS::get_joint_state_topic_id() -> decltype(m_joint_state_topic_id) {
+    return m_joint_state_topic_id;
+}
+
+void ThrusterROS::set_joint_state_topic_id(const decltype(m_joint_state_topic_id) &topic_id) {
+    m_joint_state_topic_id = topic_id;
+}
+
+auto ThrusterROS::get_joint_state_desired_topic_id() -> decltype(m_joint_state_desired_topic_id) {
+    return m_joint_state_desired_topic_id;
+}
+
+void ThrusterROS::set_joint_state_desired_topic_id(const decltype(m_joint_state_desired_topic_id) &topic_id) {
+    m_joint_state_desired_topic_id = topic_id;
+}
+
 auto ThrusterROS::get_id() -> decltype(m_id) {
     return m_id;
 }
@@ -77,21 +108,59 @@ void ThrusterROS::set_contribution_vector(const decltype(m_contribution_vector)&
     m_contribution_vector = contribution_vector;
 }
 
+void ThrusterROS::set_servo_joints(const std::vector<std::string>& joints) {
+    servo_joints = joints;
+}
+
+std::vector<std::string> ThrusterROS::get_servo_joints() const {
+    return servo_joints;
+}
+
+int ThrusterROS::get_is_articulated() const {
+    return is_articulated;
+}
+void ThrusterROS::set_is_articulated(int value) {
+    is_articulated = value;
+}
+
+const std::vector<double>& ThrusterROS::getServoSpeeds() const {
+    return servo_speeds;
+}
+
+void ThrusterROS::setServoSpeeds(const std::vector<double>& speeds) {
+    servo_speeds = speeds;
+}
+
 void ThrusterROS::initialize() {
 
     if(!m_thrust_command_topic_id.empty()) {
         m_thrust_publisher = m_nh.advertise<std_msgs::Float64>(
             m_thrust_command_topic_id, 100);
     } else {
-        throw control_ros_exception("empty topic name");
+        throw control_ros_exception("empty command topic name");
     }
 
     if(!m_thrust_command_topic_id.empty()) {
          m_force_publisher = m_nh.advertise<std_msgs::Float64>(
              m_thrust_force_topic_id, 100);
     } else {
-        throw control_ros_exception("empty topic name");
+        throw control_ros_exception("empty force topic name");
     }
+
+    if (!m_joint_state_desired_topic_id.empty()) {
+        m_joint_state_publisher = m_nh.advertise<sensor_msgs::JointState>(
+            m_joint_state_desired_topic_id, 100);
+    } else {
+        throw control_ros_exception("empty joint state topic name");
+    }    
+
+    // Initialization for the servo command topic
+    if (!m_servo_command_topic_id.empty()) {
+        m_servo_command_publisher = m_nh.advertise<std_msgs::Float64>(m_servo_command_topic_id, 100);
+    } else {
+        ROS_WARN_STREAM("Servo command topic name is empty, assuming the thruster is not articulated.");
+    }
+
 }
 
 auto ThrusterROS::get_link_id() -> decltype(m_link_id) {
@@ -102,10 +171,32 @@ void ThrusterROS::set_link_id(const decltype(m_link_id)& link_id) {
     m_link_id = link_id;
 }
 
+auto ThrusterROS::get_servo_link_id() -> decltype(m_servo_link_id) {
+    return m_servo_link_id;
+}
+
+void ThrusterROS::set_servo_link_id(const decltype(m_servo_link_id)& servo_link_id) {
+    m_servo_link_id = servo_link_id;
+}
+
+auto ThrusterROS::get_frame_id() -> decltype(m_frame_id) {
+    return m_frame_id;
+}
+
+void ThrusterROS::set_frame_id(const decltype(m_frame_id)& frame_id) {
+    m_frame_id = frame_id;
+}
+
 void ThrusterROS::command(double cmd) {
     std_msgs::Float64 msg;
     msg.data = cmd;
     m_thrust_publisher.publish(msg);
+}
+
+void ThrusterROS::servo_joint_command(double cmd) {
+    std_msgs::Float64 msg;
+    msg.data = cmd;
+    m_servo_command_publisher.publish(msg);
 }
 
 auto ThrusterROS::get_poly_solver() -> decltype(m_poly_solver) {
@@ -114,6 +205,14 @@ auto ThrusterROS::get_poly_solver() -> decltype(m_poly_solver) {
 
 void ThrusterROS::set_poly_solver(decltype(m_poly_solver) solver) {
     m_poly_solver = std::move(solver);
+}
+
+void ThrusterROS::set_servo_coeff(const std::vector<double>& coeff) {
+    servo_coeff_ = coeff;
+}
+
+const std::vector<double>& ThrusterROS::get_servo_coeff() const {
+    return servo_coeff_;
 }
 
 bool ThrusterROS::request_force(double N) {
@@ -149,4 +248,39 @@ bool ThrusterROS::request_force(double N) {
     }
 
     return true;
+}
+
+bool ThrusterROS::request_joint_angles(const std::string& joint_name, double requested_angle) {
+
+    if (!m_joint_state_publisher) {
+        ROS_ERROR("Joint state publisher is not initialized!");
+        return false;
+    }
+
+    sensor_msgs::JointState joint_state_msg;
+    // joint_state_msg.header.stamp = ros::Time::now(); 
+    joint_state_msg.name.push_back(joint_name);     
+    joint_state_msg.position.push_back(requested_angle);
+
+    m_joint_state_publisher.publish(joint_state_msg); 
+
+    servo_joint_command(normalize_angle(requested_angle));
+
+    return true;
+}
+
+double ThrusterROS::normalize_angle(double angle) const {
+    // Check that the polynomial has the expected four coefficients (slope, offset1, offset2, center)
+    if (servo_coeff_.size() != 2) {
+        throw std::runtime_error("Servo polynomial must have exactly 4 coefficients.");
+    }
+
+    double slope = servo_coeff_[0];
+    double offset = servo_coeff_[1];
+
+    // Apply the linear transformation with the chosen offset
+    double pwm = slope * angle + offset;
+
+    // Clamp the pwm to the range -1 to 1
+    return std::max(std::min(pwm, 1.0), -1.0);
 }

--- a/src/mvp_control/thruster_ros.h
+++ b/src/mvp_control/thruster_ros.h
@@ -18,7 +18,11 @@
     Email: emircem@uri.edu;emircem.gezer@gmail.com
     Year: 2022
 
-    Copyright (C) 2022 Smart Ocean Systems Laboratory
+    Author: Farhang Naderi
+    Email: farhang.naderi@uri.edu;farhang.nba@gmail.com
+    Year: 2024
+
+    Copyright (C) 2024 Smart Ocean Systems Laboratory
 */
 
 #pragma once
@@ -27,7 +31,7 @@
 #include "std_msgs/Float64.h"
 #include "Eigen/Dense"
 #include "polynomial_solver.h"
-
+#include "sensor_msgs/JointState.h"
 
 namespace ctrl {
 
@@ -41,10 +45,12 @@ namespace ctrl {
 
         friend MvpControlROS;
 
-
         //! @brief Public node handler
         ros::NodeHandle m_nh;
 
+        //! @brief Private node handler for accessing private parameters
+        ros::NodeHandle m_pnh;
+        
         //! @brief Thruster ID
         std::string m_id;
 
@@ -54,8 +60,22 @@ namespace ctrl {
         //! @brief Thruster force topic id
         std::string m_thrust_force_topic_id;
 
+        //! @brief Servo command topic id
+        std::string m_servo_command_topic_id;
+        
         //! @brief thruster link id
         std::string m_link_id;
+
+        //! @brief servo link id
+        std::string m_servo_link_id;
+
+        //! @brief thruster frame id
+        std::string m_frame_id;
+
+        std::vector<double> servo_speeds; 
+
+        //! @brief Transform prefix
+        std::string m_tf_prefix_thruster;
 
         /** @brief Thruster contribution vector
          *
@@ -65,23 +85,85 @@ namespace ctrl {
          */
         Eigen::VectorXd m_contribution_vector;
 
+        /** @brief Stores the IDs of servo joints associated with this thruster.
+         *
+         * This vector contains the IDs of all servo joints that are associated
+         * with a particular thruster. Each thruster may control or affect multiple
+         * servo joints, and this variable maps a thruster to its corresponding
+         * servo joints. 
+         */
+        std::vector<std::string> servo_joints; 
+
         //! @brief Thrust publisher
         ros::Publisher m_thrust_publisher;
+
+        //! @brief Servo angle command publisher
+        ros::Publisher m_servo_command_publisher;
 
         //! @brief Thrust force publisher
         ros::Publisher m_force_publisher;
 
+        //! @brief Servo Joint publisher
+        ros::Publisher m_joint_state_publisher;
+
+        //! @brief Joint state topic ID
+        std::string m_joint_state_topic_id;
+
+        //! @brief Joint state desired topic ID
+        std::string m_joint_state_desired_topic_id;
+
         //! @brief Polynomial solver
         PolynomialSolver::Ptr m_poly_solver;
 
+        //! @brief Servo calibration coefficients
+        std::vector<double> servo_coeff_;  
+        
+        //! @brief Servo speed rad/s
+        double m_omega;
+
+        //! @brief Maximum force limit
         double m_force_max;
 
+        //! @brief Minimum force limit
         double m_force_min;
 
+        //! @brief Maximum angle limit
+        double m_angle_max;
+
+        //! @brief Minimum angle limit
+        double m_angle_min;
+
+        //! @brief If the thruster is articulated
+        int is_articulated;
+        
     public:
 
         //! @brief Default constructor
         ThrusterROS();
+
+        /** @brief Gets whether the thruster is articulated.
+         *
+         * @return True if the thruster is articulated, false otherwise.
+         */
+        int get_is_articulated() const;
+
+        /** @brief Sets whether the thruster is articulated.
+         *
+         * @param value True to set the thruster as articulated, false to set it as non-articulated.
+         */
+        void set_is_articulated(int value);
+        
+        /** @brief Sets the servo joints associated with the thruster.
+         *
+         * @param joints A vector of strings containing the IDs of the servo joints associated with the thruster.
+         */
+        void set_servo_joints(const std::vector<std::string>& joints);
+
+        /** @brief Gets the servo joints associated with the thruster.
+         *
+         * @return A vector of strings containing the IDs of the servo joints associated with the thruster.
+         */
+        std::vector<std::string> get_servo_joints() const;
 
         /** @brief Thruster ROS class constructor.
          *
@@ -124,8 +206,43 @@ namespace ctrl {
          *
          * @param topic_id
          */
-        void set_thrust_force_topic_id(
-            const decltype(m_thrust_force_topic_id) &topic_id);
+        void set_thrust_force_topic_id(const decltype(m_thrust_force_topic_id) &topic_id);
+
+        /** @brief Trivial getter for servo command topic id
+         *
+         * @return #ThrusterROS::m_servo_command_topic_id
+         */
+        auto get_servo_command_topic_id() -> decltype(m_servo_command_topic_id);
+
+        /** @brief Default Setter servo command for topic id
+         *
+         * @param topic_id
+         */
+        void set_servo_command_topic_id(const decltype(m_servo_command_topic_id) &topic_id);
+
+        /** @brief Trivial getter for joint state topic id
+         *
+         * @return The topic ID for publishing joint states
+         */
+        auto get_joint_state_topic_id() -> decltype(m_joint_state_topic_id);
+
+        /** @brief Default Setter for joint state topic id
+         *
+         * @param topic_id The topic ID to set for publishing joint states
+         */
+        void set_joint_state_topic_id(const decltype(m_joint_state_topic_id) &topic_id);
+
+        /** @brief Trivial getter for joint state topic id
+         *
+         * @return The topic ID for publishing joint states
+         */
+        auto get_joint_state_desired_topic_id() -> decltype(m_joint_state_topic_id);
+
+        /** @brief Default Setter for joint state topic id
+         *
+         * @param topic_id The topic ID to set for publishing joint states
+         */
+        void set_joint_state_desired_topic_id(const decltype(m_joint_state_topic_id) &topic_id);
 
         /** @brief Trivial getter for link id
          *
@@ -139,6 +256,29 @@ namespace ctrl {
          */
         void set_link_id(const decltype(m_link_id) &link_id);
 
+        /** @brief Trivial getter for servo_link id
+         *
+         * @return #ThrusterROS::m_servo_link_id
+         */
+        auto get_servo_link_id() -> decltype(m_servo_link_id);
+
+        /** @brief Trivial Setter for link id
+         *
+         * @param servo_link_id
+         */
+        void set_servo_link_id(const decltype(m_servo_link_id) &servo_link_id);
+
+        /** @brief Trivial getter for frame id
+         *
+         * @return #ThrusterROS::m_frame_id
+         */
+        auto get_frame_id() -> decltype(m_frame_id);
+
+        /** @brief Trivial Setter for frame id
+         *
+         * @param frame_id
+         */
+        void set_frame_id(const decltype(m_frame_id) &frame_id);
 
         /** @brief Trivial getter for thruster id
          *
@@ -176,9 +316,33 @@ namespace ctrl {
          * @param solver
          */
         void set_poly_solver(decltype(m_poly_solver) solver);
+  
+        /** @brief Trivial setter for servo coefficients
+         *
+         * @param coeff A vector containing the servo calibration coefficients
+         */
+        void set_servo_coeff(const std::vector<double>& coeff);
+
+        /** @brief Trivial getter for servo coefficients
+         *
+         * @return A vector containing the servo calibration coefficients
+         */
+        const std::vector<double>& get_servo_coeff() const;
 
         //! @brief Generic typedef for shared pointer
         typedef std::shared_ptr<ThrusterROS> Ptr;
+
+        /** @brief Trivial getter for servo speeds
+         *
+         * @return A constant reference to the vector of servo speeds
+         */
+        const std::vector<double>& getServoSpeeds() const;
+
+        /** @brief Trivial setter for servo speeds
+         *
+         * @param speeds The vector of servo speeds to set
+         */
+        void setServoSpeeds(const std::vector<double>& speeds);
 
         /** @brief Publish thruster command
          *
@@ -187,6 +351,14 @@ namespace ctrl {
          * @param cmd
          */
         void command(double cmd);
+
+        /** @brief Publish servo command
+         *
+         * Servo command should be between -1 and 1
+         *
+         * @param normalized_angle
+         */
+        void servo_joint_command(double normalized_angle);
 
         /** @brief Request force from thruster
          *
@@ -197,6 +369,25 @@ namespace ctrl {
          * @return true if polynomial is solved, false if polynomial isn't solved.
          */
         bool request_force(double N);
+
+        /**
+         * @brief Publishes the requested angle for a given joint name.
+         *
+         * This method publishes the desired joint angle to servo hardware
+         *
+         * @param joint_name The name of the joint.
+         * @param requested_angle The requested angle for the joint in radians.
+         * @return true if the joint state is successfully published
+         */
+        bool request_joint_angles(const std::string& joint_name, double requested_angle);
+
+        /** @brief Normalize the angle to PWM using the servo coefficients
+         *
+         * @param angle The input angle
+         * @return The normalized PWM value
+         */
+        double normalize_angle(double angle) const;
+        
     };
 
 }


### PR DESCRIPTION
This PR introduces articulated thrusters capabilities to the current MVP-Control. You can find the examples how to add your articulated thrusters to the current vehicle:

[URDF Example](https://github.com/GSO-soslab/race2_auv/blob/noetic-devel/race2_description/urdf/base.urdf.xacro)

[Stonefish Example](https://github.com/GSO-soslab/world_of_stonefish/blob/main/vehicles/race2.scn.xacro)

[Config file example](https://github.com/GSO-soslab/race2_auv/blob/noetic-devel/race2_config/config/control_sim.yaml)